### PR TITLE
Update config.default.sh

### DIFF
--- a/config.default.sh
+++ b/config.default.sh
@@ -1,13 +1,20 @@
+global_api_key="YOUR_GLOBAL_KEY"
+email="admin@example.com"
+
 case ${1} in
-	"www.example.com")
-		global_api_key="YOUR_GLOBAL_KEY"
-		zones="YOUR_ZONES"
-		email="admin@example.com"
+	"example.com")
+		zones="zoneidhere01"
 	;;
 
-	"www.example.net")
-		global_api_key="ANOTHER_GLOBAL_KEY"
-		zones="ANOTHER_ZONE"
-		email="webmaster@example.net"
+	*".example.com")
+		zones="zoneidhere01"
+	;;
+	
+	"example.net")
+		zones="zoneidhere02"
+	;;
+
+	*".example.net")
+		zones="zoneidhere02"
 	;;
 esac


### PR DESCRIPTION
The global API key and email address should stay the same for most people as multiple domains are manged by a single account, the only variable that changes is the Zone ID key for each domain. If a domain is on a different account a user can set the global api key and email for that particular domain to be different, overriding the previously set variable.

I believe this example config makes more sense and is cleaner. I was confused and thrown off by yours and manage several sub-domains for each domain.. I used this format for my config and it worked excellent.