### PR TITLE
Add support for using API tokens instead of email+global API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 + Update Docker instructions
 + Update error codes
++ Add support for using API tokens instead of email+global API key
 
 ## 4.0.0
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ home.example.net
 | Value          | Where to find |
 | -------------- | ------------- |
 | Zone ID        | Main page domain > Right Column > API section |
+| API Token      | Account > My Profile > API Tokens > Create Token |
 | Global API Key | Account > My Profile > API Tokens > Api Keys > Global API Key |
+
+You can choose between using an **API token** and using your **global API key**. It is preferred to create a token, since tokens can be restricted to just the permission to edit DNS records in chosen zones (the `DNS:Edit` permission).
+
+If you choose to use an API token, it must be filled into `api_token`. If you want to use your global API key, instead use `global_api_key` and `email`.
 
 ### Classic mode: Usage
 

--- a/config.default.sh
+++ b/config.default.sh
@@ -1,13 +1,16 @@
+# Instead of api_token, you can also use your global API key. For example:
+#     global_api_key="YOUR_GLOBAL_KEY"
+#     zones="YOUR_ZONES"
+#     email="admin@example.com"
+
 case ${1} in
 	"www.example.com")
-		global_api_key="YOUR_GLOBAL_KEY"
+		api_token="YOUR_API_TOKEN"
 		zones="YOUR_ZONES"
-		email="admin@example.com"
 	;;
 
 	"www.example.net")
-		global_api_key="ANOTHER_GLOBAL_KEY"
+		api_token="ANOTHER_API_TOKEN"
 		zones="ANOTHER_ZONE"
-		email="webmaster@example.net"
 	;;
 esac


### PR DESCRIPTION
Cloudflare added support for a new type of token which can be scoped and restricted in usage. For example, it can be set to only allow editing DNS records in specific zones and from certain IP ranges, whereas global API keys have full account access.

Documentation on API tokens can be found here:
https://developers.cloudflare.com/api/tokens

The old global API keys are still supported, and will be attempted to be used if the API token is not configured.